### PR TITLE
Add restore id broadcast receiver for android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,4 +32,5 @@ android {
 
 dependencies {
     implementation 'com.github.freshdesk:freshchat-android:3.3.0'
+    implementation "androidx.localbroadcastmanager:localbroadcastmanager:1.0.0"
 }

--- a/android/src/main/java/com/freshchat/flutter_freshchat/FlutterFreshchatPlugin.java
+++ b/android/src/main/java/com/freshchat/flutter_freshchat/FlutterFreshchatPlugin.java
@@ -4,6 +4,8 @@ import android.app.Application;
 import android.util.Log;
 import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -58,6 +60,11 @@ public class FlutterFreshchatPlugin implements MethodCallHandler {
 
     private FlutterFreshchatPlugin(Application application) {
         this.application = application;
+    }
+
+    private void registerRestoreIdBroadcastReceiver() {
+        IntentFilter intentFilterRestoreID = new IntentFilter(Freshchat.FRESHCHAT_USER_RESTORE_ID_GENERATED);
+        getLocalBroadcastManager().registerReceiver(restoreIdReceiver, intentFilterRestoreID);
     }
 
     private LocalBroadcastManager getLocalBroadcastManager() {

--- a/android/src/main/java/com/freshchat/flutter_freshchat/FlutterFreshchatPlugin.java
+++ b/android/src/main/java/com/freshchat/flutter_freshchat/FlutterFreshchatPlugin.java
@@ -100,6 +100,7 @@ public class FlutterFreshchatPlugin implements MethodCallHandler {
             freshchatConfig.setTeamMemberInfoVisible(teamMemberInfoVisible);
             freshchatConfig.setDomain(domain);
             Freshchat.getInstance(this.application.getApplicationContext()).init(freshchatConfig);
+            this.registerRestoreIdBroadcastReceiver();
             result.success(true);
             break;
         case METHOD_GET_USER_RESTORE_ID:

--- a/android/src/main/java/com/freshchat/flutter_freshchat/FlutterFreshchatPlugin.java
+++ b/android/src/main/java/com/freshchat/flutter_freshchat/FlutterFreshchatPlugin.java
@@ -108,20 +108,21 @@ public class FlutterFreshchatPlugin implements MethodCallHandler {
             break;
         case METHOD_IDENTIFY_USER:
             final String externalId = call.argument("externalID");
-            String restoreId = call.argument("restoreID");
+            String receivedRestoreId = call.argument("restoreID");
 
             try {
-                if (restoreId == "") {
+                if (receivedRestoreId.isEmpty()) {
                     Freshchat.getInstance(this.application.getApplicationContext()).identifyUser(externalId, null);
-                    restoreId = Freshchat.getInstance(this.application.getApplicationContext()).getUser().getRestoreId();
+                    this.restoreId = Freshchat.getInstance(this.application.getApplicationContext()).getUser().getRestoreId();
                 } else {
-                    Freshchat.getInstance(this.application.getApplicationContext()).identifyUser(externalId, restoreId);
+                    Freshchat.getInstance(this.application.getApplicationContext()).identifyUser(externalId, receivedRestoreId);
+                    this.restoreId = receivedRestoreId;
                 }
             } catch (MethodNotAllowedException e) {
                 e.printStackTrace();
                 result.error("Error while identifying User", "error", e);
             }
-            result.success(restoreId);
+            result.success(this.restoreId);
             break;
         case METHOD_UPDATE_USER_INFO:
             final String firstName = call.argument("first_name");

--- a/android/src/main/java/com/freshchat/flutter_freshchat/FlutterFreshchatPlugin.java
+++ b/android/src/main/java/com/freshchat/flutter_freshchat/FlutterFreshchatPlugin.java
@@ -2,6 +2,8 @@ package com.freshchat.flutter_freshchat;
 
 import android.app.Application;
 import android.util.Log;
+import android.content.BroadcastReceiver;
+import android.content.Context;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -22,6 +24,8 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
 public class FlutterFreshchatPlugin implements MethodCallHandler {
     private final Application application;
 
@@ -36,6 +40,16 @@ public class FlutterFreshchatPlugin implements MethodCallHandler {
     private static final String METHOD_SEND_MESSAGE = "send";
     private static final String METHOD_GET_USER_RESTORE_ID = "getUserRestoreId";
     private String restoreId = "";
+    private BroadcastReceiver restoreIdReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            String receivedRestoreId = Freshchat.getInstance(getApplicationContext()).getUser().getRestoreId();            
+
+            setUserRestoreId(receivedRestoreId);            
+            getLocalBroadcastManager().unregisterReceiver(restoreIdReceiver);
+        }
+
+    };
 
     public static void registerWith(Registrar registrar) {
         final MethodChannel channel = new MethodChannel(registrar.messenger(), "flutter_freshchat");
@@ -44,6 +58,14 @@ public class FlutterFreshchatPlugin implements MethodCallHandler {
 
     private FlutterFreshchatPlugin(Application application) {
         this.application = application;
+    }
+
+    private LocalBroadcastManager getLocalBroadcastManager() {
+        return LocalBroadcastManager.getInstance(getApplicationContext());
+    }
+
+    private Context getApplicationContext(){
+        return this.application.getApplicationContext();
     }
 
     private void setUserRestoreId(String userRestoreId){

--- a/android/src/main/java/com/freshchat/flutter_freshchat/FlutterFreshchatPlugin.java
+++ b/android/src/main/java/com/freshchat/flutter_freshchat/FlutterFreshchatPlugin.java
@@ -34,6 +34,8 @@ public class FlutterFreshchatPlugin implements MethodCallHandler {
     private static final String METHOD_GET_UNREAD_MESSAGE_COUNT = "getUnreadMsgCount";
     private static final String METHOD_SETUP_PUSH_NOTIFICATIONS = "setupPushNotifications";
     private static final String METHOD_SEND_MESSAGE = "send";
+    private static final String METHOD_GET_USER_RESTORE_ID = "getUserRestoreId";
+    private String restoreId = "";
 
     public static void registerWith(Registrar registrar) {
         final MethodChannel channel = new MethodChannel(registrar.messenger(), "flutter_freshchat");
@@ -42,6 +44,10 @@ public class FlutterFreshchatPlugin implements MethodCallHandler {
 
     private FlutterFreshchatPlugin(Application application) {
         this.application = application;
+    }
+
+    private void setUserRestoreId(String userRestoreId){
+        this.restoreId = userRestoreId;
     }
 
     @Override
@@ -66,6 +72,9 @@ public class FlutterFreshchatPlugin implements MethodCallHandler {
             freshchatConfig.setDomain(domain);
             Freshchat.getInstance(this.application.getApplicationContext()).init(freshchatConfig);
             result.success(true);
+            break;
+        case METHOD_GET_USER_RESTORE_ID:
+            result.success(this.restoreId);
             break;
         case METHOD_IDENTIFY_USER:
             final String externalId = call.argument("externalID");

--- a/lib/src/freshchat.dart
+++ b/lib/src/freshchat.dart
@@ -100,6 +100,13 @@ class FlutterFreshchat {
     return result;
   }
 
+  /// Returns a `restoreID` you can save it on your backend
+  /// and use to restore the user chats messages.
+  static Future<String> getUserRestoreId() async {
+    final String result = await _channel.invokeMethod("getUserRestoreId");
+    return result;
+  }
+
   /// Show conversation opens a conversation screen and also list all the other
   /// conversation if a list obejct is supplied to it.
   ///


### PR DESCRIPTION
In this PR was added a BroadcastReceiver to get the user restoreID as mention in Freshchat documentation: https://support.freshchat.com/support/solutions/articles/50000000207-freshchat-android-sdk-integration-steps section 3.5.

The broadcastReceiver will listen to the Freshchat service that will send the restoreId only after the user sends the first message. It is registered on the INIT_METHOD and unregistered when the restoreId is received.

Was added a method `getUserRestoreId` on Flutter interface to allow the user to get its restoreId.